### PR TITLE
changed arduino.h to Arduino.h

### DIFF
--- a/SamVESC.h
+++ b/SamVESC.h
@@ -21,7 +21,7 @@ along with this program.If not, see <http://www.gnu.org/licenses/>.
 
 #define DEBUGSERIAL Serial
 
-#include "arduino.h" 
+#include "Arduino.h" 
 #include "datatypes.h"
 #include "local_datatypes.h"
 


### PR DESCRIPTION
fixes error when compiled on case-sensitive operating systems such as ubuntu